### PR TITLE
ui/cocoa: capture Command-Tab when mouse is grabbed

### DIFF
--- a/include/ui/cocoa.h
+++ b/include/ui/cocoa.h
@@ -51,6 +51,7 @@ typedef struct {
     int mouse_on;
     CGImageRef cursor_cgimage;
     int cursor_show;
+    bool full_grab;
     bool inited;
 } QEMUScreen;
 
@@ -64,6 +65,7 @@ typedef struct {
     QKbdState *kbd;
     BOOL isMouseGrabbed;
     BOOL isAbsoluteEnabled;
+    CFMachPortRef eventsTap;
 }
 - (id)initWithFrame:(NSRect)frameRect
              screen:(QEMUScreen *)given_screen;
@@ -87,6 +89,7 @@ typedef struct {
  */
 - (BOOL) isMouseGrabbed;
 - (BOOL) isAbsoluteEnabled;
+- (BOOL) isFullGrabEnabled;
 - (void) setNeedsDisplayForCursorX:(int)x
                                  y:(int)y
                              width:(int)width

--- a/qapi/ui.json
+++ b/qapi/ui.json
@@ -1100,6 +1100,20 @@
   'data'    : { '*charset'       : 'str' } }
 
 ##
+# @DisplayCocoa:
+#
+# Cocoa display options.
+#
+# @full-grab:       Capture all key presses, including system combos. This
+#                   requires accessibility permissions, since it performs
+#                   a global grab on key events. (default: off)
+#                   See https://support.apple.com/en-in/guide/mac-help/mh32356/mac
+#
+##
+{ 'struct'  : 'DisplayCocoa',
+  'data'    : { '*full-grab'     : 'bool' } }
+
+##
 # @DisplayType:
 #
 # Display (user interface) type.
@@ -1164,6 +1178,7 @@
                 '*gl'            : 'DisplayGLMode' },
   'discriminator' : 'type',
   'data'    : { 'gtk'            : 'DisplayGTK',
+                'cocoa'          : 'DisplayCocoa',
                 'curses'         : 'DisplayCurses',
                 'egl-headless'   : 'DisplayEGLHeadless'} }
 

--- a/qemu-options.hx
+++ b/qemu-options.hx
@@ -1786,6 +1786,9 @@ DEF("display", HAS_ARG, QEMU_OPTION_display,
 #if defined(CONFIG_CURSES)
     "-display curses[,charset=<encoding>]\n"
 #endif
+#if defined(CONFIG_COCOA)
+    "-display cocoa[,full_grab=on|off]\n"
+#endif
 #if defined(CONFIG_OPENGL) && defined(CONFIG_EGL)
     "-display egl-headless[,rendernode=<file>]\n"
 #endif

--- a/ui/cocoa/main.m
+++ b/ui/cocoa/main.m
@@ -680,6 +680,7 @@ static void cocoa_display_init(DisplayState *ds, DisplayOptions *opts)
     COCOA_DEBUG("qemu_cocoa: cocoa_display_init\n");
 
     screen.cursor_show = opts->has_show_cursor && opts->show_cursor;
+    screen.full_grab = opts->u.cocoa.full_grab;
 
     /* Tell main thread to go ahead and create the app and enter the run loop */
     qemu_sem_post(&display_init_sem);


### PR DESCRIPTION
This is a first try at making my Gnome experience a bit more natural. I use both Alt-Tab and Super-Tab with different behaviours, so I was getting really upset when I hit Alt-Tab out of muscle memory and it switched me away from the VM.

I don't think this patch is ready to submit upstream, but I thought I'd send a PR to your branch so you can review and see if you have any ideas of how this could be implemented better.

I think this should probably be behind a command line switch like --alt-grab on other ui backend (or maybe we just reuse --alt-grab?). And I would very much like to not depend on something that requires giving accessibility control to the Terminal heh (I guess we could have some kind of .App wrapper, kind of like UTM?).

Or maybe there is another API other than CG Events Tap that makes it possible to watch for these system events when the application is focused? I would very much prefer that, it is not great that it is going over every key stroke even when it's not focused.